### PR TITLE
update to support setting line ending in property

### DIFF
--- a/src/main/java/au/com/acegi/xmlformat/LineEnding.java
+++ b/src/main/java/au/com/acegi/xmlformat/LineEnding.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * XML Format Maven Plugin
+ * %%
+ * Copyright (C) 2011 - 2017 Acegi Technology Pty Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package au.com.acegi.xmlformat;
+
+public enum LineEnding {
+
+  SYSTEM_DEFAULT(),
+  LF("\n"),
+  CRLF("\r\n"),
+  CR("\r");
+
+  private final String chars;
+
+  LineEnding() {
+    this.chars = System.lineSeparator();
+  }
+
+  LineEnding(final String value) {
+    this.chars = value;
+  }
+
+  public String getChars() {
+    return this.chars;
+  }
+
+}

--- a/src/main/java/au/com/acegi/xmlformat/LineEnding.java
+++ b/src/main/java/au/com/acegi/xmlformat/LineEnding.java
@@ -22,7 +22,7 @@ package au.com.acegi.xmlformat;
 
 public enum LineEnding {
 
-  SYSTEM_DEFAULT(),
+  SYSTEM(),
   LF("\n"),
   CRLF("\r\n"),
   CR("\r");

--- a/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
@@ -20,24 +20,23 @@
 
 package au.com.acegi.xmlformat;
 
-import static au.com.acegi.xmlformat.FormatUtil.*;
-import static java.util.Arrays.*;
-import static org.apache.maven.plugins.annotations.LifecyclePhase.*;
-import static org.dom4j.io.OutputFormat.*;
-
+import static au.com.acegi.xmlformat.FormatUtil.formatInPlace;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.copyOf;
 import java.util.List;
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import static org.apache.maven.plugins.annotations.LifecyclePhase.PREPARE_PACKAGE;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.dom4j.DocumentException;
 import org.dom4j.io.OutputFormat;
+import static org.dom4j.io.OutputFormat.createPrettyPrint;
 
 /**
  * Finds the XML files in a project and automatically reformats them.

--- a/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
@@ -20,23 +20,24 @@
 
 package au.com.acegi.xmlformat;
 
-import static au.com.acegi.xmlformat.FormatUtil.formatInPlace;
+import static au.com.acegi.xmlformat.FormatUtil.*;
+import static java.util.Arrays.*;
+import static org.apache.maven.plugins.annotations.LifecyclePhase.*;
+import static org.dom4j.io.OutputFormat.*;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import static java.util.Arrays.asList;
-import static java.util.Arrays.copyOf;
 import java.util.List;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import static org.apache.maven.plugins.annotations.LifecyclePhase.PREPARE_PACKAGE;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.dom4j.DocumentException;
 import org.dom4j.io.OutputFormat;
-import static org.dom4j.io.OutputFormat.createPrettyPrint;
 
 /**
  * Finds the XML files in a project and automatically reformats them.
@@ -97,6 +98,19 @@ public final class XmlFormatPlugin extends AbstractMojo {
   @Parameter(property = "lineSeparator", defaultValue = "\n")
   @SuppressWarnings("PMD.ImmutableField")
   private String lineSeparator = "\n";
+
+  /**
+   * Sets the line-ending of files after formatting. Valid values are:
+   * <ul>
+   * <li><b>"SYSTEM"</b> - Use line endings of current system</li>
+   * <li><b>"LF"</b> - Use Unix and Mac style line endings</li>
+   * <li><b>"CRLF"</b> - Use DOS and Windows style line endings</li>
+   * <li><b>"CR"</b> - Use early Mac style line endings</li>
+   * </ul>
+   */
+  @Parameter(property = "lineEnding", defaultValue = "LF")
+  @SuppressWarnings("PMD.ImmutableField")
+  private LineEnding lineEnding = LineEnding.LF;
 
   /**
    * Whether or not to print new line after the XML declaration.
@@ -224,7 +238,7 @@ public final class XmlFormatPlugin extends AbstractMojo {
     fmt.setEncoding(encoding);
     fmt.setExpandEmptyElements(expandEmptyElements);
     fmt.setIndentSize(indentSize);
-    fmt.setLineSeparator(lineSeparator);
+    fmt.setLineSeparator(determineLineSeparator());
     fmt.setNewLineAfterDeclaration(newLineAfterDeclaration);
     fmt.setNewLineAfterNTags(newLineAfterNTags);
     fmt.setNewlines(newlines);
@@ -250,5 +264,9 @@ public final class XmlFormatPlugin extends AbstractMojo {
 
     dirScanner.scan();
     return dirScanner.getIncludedFiles();
+  }
+
+  private String determineLineSeparator() {
+    return "\n".equals(lineSeparator) ? lineEnding.getChars() : lineSeparator;
   }
 }


### PR DESCRIPTION
I need to set the line endings to windows style line endings. However, current property lineSeparator cannot be set in pom.xml as setting it to \r\n sets it to the string "\r\n", not CRLF. I took inspiration from https://github.com/revelc/formatter-maven-plugin/ and added a line ending enum.

Set the default to the same LF line ending and added backward compatibility, i.e. the new property is only considered if the current property has it's default value. As such, anyone using the plugin with either the default value or a custom value see the same behaviour.

The new property is lineEnding and the supported values are SYSTEM (uses system line endings), LF, CRLF or CR. the default is LF