### PR TITLE
fix for Issue 16

### DIFF
--- a/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
@@ -192,9 +192,7 @@ public final class XmlFormatPlugin extends AbstractMojo {
       return;
     }
 
-    if (includes == null || includes.length == 0) {
-      includes = new String[]{"**/*.xml"};
-    }
+    initializeIncludes();
 
     final OutputFormat fmt = buildFormatter();
 
@@ -239,6 +237,12 @@ public final class XmlFormatPlugin extends AbstractMojo {
 
   void setTargetDirectory(final File targetDirectory) {
     this.targetDirectory = targetDirectory;
+  }
+  
+  private void initializeIncludes() {
+    if (includes == null || includes.length == 0) {
+      includes = new String[]{"**/*.xml"};
+    }
   }
 
   private OutputFormat buildFormatter() {

--- a/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
@@ -70,7 +70,7 @@ public final class XmlFormatPlugin extends AbstractMojo {
    * the formatting. In addition to these exclusions, the project build
    * directory (typically <code>target</code>) is always excluded.
    */
-  @Parameter(property = "excludes", defaultValue = "")
+  @Parameter(property = "excludes")
   private String[] excludes;
 
   /**
@@ -185,7 +185,6 @@ public final class XmlFormatPlugin extends AbstractMojo {
   public void execute() throws MojoExecutionException, MojoFailureException {
     assert baseDirectory != null;
     assert targetDirectory != null;
-    assert excludes != null;
 
     if (skip) {
       getLog().info("[xml-format] Skipped");
@@ -193,6 +192,7 @@ public final class XmlFormatPlugin extends AbstractMojo {
     }
 
     initializeIncludes();
+    initializeExcludes();
 
     final OutputFormat fmt = buildFormatter();
 
@@ -242,6 +242,12 @@ public final class XmlFormatPlugin extends AbstractMojo {
   private void initializeIncludes() {
     if (includes == null || includes.length == 0) {
       includes = new String[]{"**/*.xml"};
+    }
+  }
+  
+  private void initializeExcludes() {
+    if (excludes == null || excludes.length == 0) {
+      excludes = new String[0];
     }
   }
 

--- a/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
@@ -82,7 +82,7 @@ public final class XmlFormatPlugin extends AbstractMojo {
    * A set of file patterns that dictate which files should be included in the
    * formatting with each file pattern being relative to the base directory.
    */
-  @Parameter(property = "includes", defaultValue = "**/*.xml")
+  @Parameter(property = "includes")
   private String[] includes;
 
   /**
@@ -185,12 +185,15 @@ public final class XmlFormatPlugin extends AbstractMojo {
   public void execute() throws MojoExecutionException, MojoFailureException {
     assert baseDirectory != null;
     assert targetDirectory != null;
-    assert includes != null && includes.length > 0;
     assert excludes != null;
 
     if (skip) {
       getLog().info("[xml-format] Skipped");
       return;
+    }
+
+    if (includes == null || includes.length == 0) {
+      includes = new String[]{"**/*.xml"};
     }
 
     final OutputFormat fmt = buildFormatter();

--- a/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
@@ -193,7 +193,7 @@ public final class XmlFormatPlugin extends AbstractMojo {
     }
 
     if (includes == null || includes.length == 0) {
-        includes = new String[]{ "**/*.xml" };
+      includes = new String[]{"**/*.xml"};
     }
 
     final OutputFormat fmt = buildFormatter();


### PR DESCRIPTION
- fixes #16
- provides a fix for maven bug [MNG-5440](https://issues.apache.org/jira/browse/MNG-5440)

The Maven issue linked is the exact issue that our team was seeing. I tried a few different ways of fixing it but this solution is the only one I could get to work correctly. I would have thought initialising the field like `private String[] includes = { "**/*.xml" };` would have worked but as I was debugging it, the array was always empty by the time it got to the `execute` method. As such, I decided to just check the array at the last second and initialise it to the default if it was empty.

Additionally, I was having a heck of a time getting the project to build in any kind of manner on my machine. Even a clean clone without any modifications by me was having test failures around the hash assertions. I ultimately had to skip tests (among other maven plugins) as I was installing it locally. So I apologise if I've missed something with this submission. 

A plugin release version 3.0.7 would be much appreciated as our team could then start utilising this plugin again. 

Thank you.