### PR TITLE
Allow indentation using tabs

### DIFF
--- a/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
@@ -89,6 +89,12 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
   private int indentSize;
 
   /**
+   * Use tabs instead of spaces for indents.
+   */
+  @Parameter(property = "tabIndent", defaultValue = "false")
+  private boolean tabIndent;
+
+  /**
    * Sets the line-ending of files after formatting. Valid values are:
    * <ul>
    * <li><b>"SYSTEM"</b> - Use line endings of current system</li>
@@ -259,6 +265,9 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
     fmt.setAttributeQuoteCharacter(attributeQuoteChar);
     fmt.setEncoding(encoding);
     fmt.setExpandEmptyElements(expandEmptyElements);
+    if (tabIndent) {
+      fmt.setIndent("\t");
+    }
     fmt.setIndentSize(indentSize);
     fmt.setLineSeparator(determineLineSeparator());
     fmt.setNewLineAfterDeclaration(newLineAfterDeclaration);

--- a/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,13 +83,14 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
   private String[] includes;
 
   /**
-   * Indicates the number of spaces to apply when indenting.
+   * Indicates the number of spaces to apply when indenting. 
    */
   @Parameter(property = "indentSize", defaultValue = "2")
   private int indentSize;
 
   /**
    * Use tabs instead of spaces for indents.
+   * If set to <code>true</code>, <code>indentSize</code> will be ignored.
    */
   @Parameter(property = "tabIndent", defaultValue = "false")
   private boolean tabIndent;
@@ -267,8 +268,9 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
     fmt.setExpandEmptyElements(expandEmptyElements);
     if (tabIndent) {
       fmt.setIndent("\t");
+    } else {
+      fmt.setIndentSize(indentSize);
     }
-    fmt.setIndentSize(indentSize);
     fmt.setLineSeparator(determineLineSeparator());
     fmt.setNewLineAfterDeclaration(newLineAfterDeclaration);
     fmt.setNewLineAfterNTags(newLineAfterNTags);

--- a/src/main/java/au/com/acegi/xmlformat/FormatUtil.java
+++ b/src/main/java/au/com/acegi/xmlformat/FormatUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/IOUtil.java
+++ b/src/main/java/au/com/acegi/xmlformat/IOUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/LineEnding.java
+++ b/src/main/java/au/com/acegi/xmlformat/LineEnding.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/XmlCheckPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlCheckPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/package-info.java
+++ b/src/main/java/au/com/acegi/xmlformat/package-info.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -3,7 +3,7 @@
   #%L
   XML Format Maven Plugin
   %%
-  Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+  Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,6 @@ public final class FormatUtilTest {
   public void test4() throws DocumentException, IOException {
     final OutputFormat fmt = createPrettyPrint();
     fmt.setIndent("\t");
-    fmt.setIndentSize(1);
     fmt.setNewLineAfterDeclaration(false);
     fmt.setPadText(false);
     testInOut(4, fmt);

--- a/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
@@ -82,6 +82,16 @@ public final class FormatUtilTest {
     testInOut(3, fmt);
   }
 
+  @Test
+  public void test4() throws DocumentException, IOException {
+    final OutputFormat fmt = createPrettyPrint();
+    fmt.setIndent("\t");
+    fmt.setIndentSize(1);
+    fmt.setNewLineAfterDeclaration(false);
+    fmt.setPadText(false);
+    testInOut(4, fmt);
+  }
+
   @Test(expected = DocumentException.class)
   public void testInvalid() throws DocumentException, IOException {
     final InputStream in = getResource("/invalid.xml");

--- a/src/test/java/au/com/acegi/xmlformat/IOTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/IOTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/TestUtil.java
+++ b/src/test/java/au/com/acegi/xmlformat/TestUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/XmlCheckPluginTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/XmlCheckPluginTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/XmlFormatPluginTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/XmlFormatPluginTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/package-info.java
+++ b/src/test/java/au/com/acegi/xmlformat/package-info.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2019 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2020 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/test4-in.xml
+++ b/src/test/resources/test4-in.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>    <parent>        <groupId>org.sonatype.oss</groupId>
+        
+        
+        <artifactId>oss-parent</artifactId>
+            <version>9</version>
+    </parent>
+    <groupId>au.com.acegi.xmlformat</groupId>
+    
+    <artifactId>xml-format-maven-plugin</artifactId>
+    <version>1.0.0</version>
+    
+    <packaging>maven-plugin  </packaging>
+
+
+</project>

--- a/src/test/resources/test4-out.xml
+++ b/src/test/resources/test4-out.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>9</version>
+	</parent>
+	<groupId>au.com.acegi.xmlformat</groupId>
+	<artifactId>xml-format-maven-plugin</artifactId>
+	<version>1.0.0</version>
+	<packaging>maven-plugin</packaging>
+</project>


### PR DESCRIPTION
- adds an additional configuration field `tabIndent` (defaults to `false`)
- if set to `true`, a single tab is used for indentation, value of `indentSize` is ignored.
- added formatter test to check expected behavior