### PR TITLE
Added option skipTargetFolder  to address #21

### DIFF
--- a/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
@@ -66,7 +66,8 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
   /**
    * A set of file patterns that allow you to exclude certain files/folders from
    * the formatting. In addition to these exclusions, the project build
-   * directory (typically <code>target</code>) is always excluded.
+   * directory (typically <code>target</code>) is always excluded if skipTargetFolder
+   * is true.
    */
   @Parameter(property = "excludes")
   private String[] excludes;
@@ -160,6 +161,13 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
    */
   @Parameter(property = "xml-format.skip", defaultValue = "false")
   private boolean skip;
+
+  /**
+   * In addition to the exclusions, the project build
+   * directory (typically <code>target</code>) is always excluded if true.
+   */
+  @Parameter(property = "skipTargetFolder", defaultValue = "true")
+  private boolean skipTargetFolder = true;
 
   /**
    * Whether or not to suppress the XML declaration.
@@ -257,6 +265,10 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
     this.skip = skip;
   }
 
+  void setSkipTargetFolder(final boolean skipTargetFolder) {
+    this.skipTargetFolder = skipTargetFolder;
+  }
+
   void setTargetDirectory(final File targetDirectory) {
     this.targetDirectory = targetDirectory;
   }
@@ -293,7 +305,8 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
     dirScanner.setIncludes(includes);
 
     final List<String> exclude = new ArrayList<>(asList(excludes));
-    if (baseDirectory.equals(targetDirectory.getParentFile())) {
+    if (skipTargetFolder
+        && baseDirectory.equals(targetDirectory.getParentFile())) {
       exclude.add(targetDirectory.getName() + "/**");
     }
     final String[] excluded = new String[exclude.size()];

--- a/src/test/java/au/com/acegi/xmlformat/XmlFormatPluginTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/XmlFormatPluginTest.java
@@ -56,6 +56,7 @@ public final class XmlFormatPluginTest {
   private static final String ERR_TXT = "<xml> <hello> hello not closed! </xml>";
   private static final String NO_CHG_TXT = "<xml> <leave-me-alone/> </xml>";
   private static final String TO_CHG_TXT = "<xml> <hello/> </xml>";
+  private static final String INCLUDE_ALL_XML = "**/*.xml";
 
   @Rule
   public TemporaryFolder tmp = new TemporaryFolder();
@@ -103,7 +104,7 @@ public final class XmlFormatPluginTest {
 
     plugin.setBaseDirectory(proj);
     plugin.setExcludes(new String[]{"**/" + ERR_FILE_NAME});
-    plugin.setIncludes(new String[]{"**/*.xml"});
+    plugin.setIncludes(new String[]{INCLUDE_ALL_XML});
     plugin.setTargetDirectory(target);
 
     plugin.execute();
@@ -127,7 +128,7 @@ public final class XmlFormatPluginTest {
 
     plugin.setBaseDirectory(proj);
     plugin.setExcludes(new String[]{""});
-    plugin.setIncludes(new String[]{"**/*.xml"});
+    plugin.setIncludes(new String[]{INCLUDE_ALL_XML});
     plugin.setTargetDirectory(target);
 
     try {
@@ -146,6 +147,28 @@ public final class XmlFormatPluginTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitUseExpected")
+  public void pluginSkipTargetFolder() throws MojoExecutionException, MojoFailureException {
+    final XmlFormatPlugin plugin = new XmlFormatPlugin();
+    plugin.setLog(log);
+
+    plugin.setSkipTargetFolder(false);
+    when(log.isDebugEnabled()).thenReturn(true);
+    when(log.isErrorEnabled()).thenReturn(true);
+
+    plugin.setBaseDirectory(proj);
+    plugin.setExcludes(new String[]{"**/" + ERR_FILE_NAME});
+    plugin.setIncludes(new String[]{INCLUDE_ALL_XML});
+    plugin.setTargetDirectory(target);
+
+    plugin.execute();
+
+    assertThat(fileToString(toChange), not(TO_CHG_TXT));
+    assertThat(fileToString(noChange), not(NO_CHG_TXT));
+    assertThat(fileToString(error), is(ERR_TXT));
+  }
+
+  @Test
   public void pluginSkip() throws MojoExecutionException, MojoFailureException {
     final XmlFormatPlugin plugin = new XmlFormatPlugin();
     plugin.setLog(log);
@@ -156,7 +179,7 @@ public final class XmlFormatPluginTest {
 
     plugin.setBaseDirectory(proj);
     plugin.setExcludes(new String[]{"**/" + ERR_FILE_NAME});
-    plugin.setIncludes(new String[]{"**/*.xml"});
+    plugin.setIncludes(new String[]{INCLUDE_ALL_XML});
     plugin.setTargetDirectory(target);
 
     plugin.execute();


### PR DESCRIPTION
Please find the required PR to address issue #21  IMHO the target folder should not be excluded since it is a mutable folder.  "skipTargetFolder" is true by default to be compatible to older versions.