### PR TITLE
Add support for preserving empty lines (at most one of them)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>hamcrest</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.8.1</version>
+    </dependency>
+    <dependency>
       <!-- Mockito 3.0.0 and above requires Java 8 (XML formatter targets Java 7) -->
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
@@ -22,7 +22,6 @@ package au.com.acegi.xmlformat;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.copyOf;
-import static org.dom4j.io.OutputFormat.createPrettyPrint;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +34,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.dom4j.DocumentException;
-import org.dom4j.io.OutputFormat;
 
 /**
  * Common infrastructure for the various plugin goals.
@@ -194,6 +192,12 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
   @Parameter(property = "xhtml", defaultValue = "false")
   private boolean xhtml;
 
+  /**
+   * Whether to keep blank lines. A maximum of one line is preserved between each tag.
+   */
+  @Parameter(property = "keepBlankLines", defaultValue = "false")
+  private boolean keepBlankLines;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     assert baseDirectory != null;
@@ -207,7 +211,7 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
     initializeIncludes();
     initializeExcludes();
 
-    final OutputFormat fmt = buildFormatter();
+    final XmlOutputFormat fmt = buildFormatter();
 
     boolean success = true;
     boolean neededFormatting = false;
@@ -236,7 +240,7 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
    * @throws DocumentException if input XML could not be parsed
    * @throws IOException       if output XML stream could not be written
    */
-  protected abstract boolean processFile(File input, OutputFormat fmt)
+  protected abstract boolean processFile(File input, XmlOutputFormat fmt)
       throws DocumentException, IOException;
 
   /**
@@ -273,8 +277,8 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
     this.targetDirectory = targetDirectory;
   }
 
-  private OutputFormat buildFormatter() {
-    final OutputFormat fmt = createPrettyPrint();
+  private XmlOutputFormat buildFormatter() {
+    final XmlOutputFormat fmt = new XmlOutputFormat();
     fmt.setAttributeQuoteCharacter(attributeQuoteChar);
     fmt.setEncoding(encoding);
     fmt.setExpandEmptyElements(expandEmptyElements);
@@ -292,6 +296,7 @@ public abstract class AbstractXmlPlugin extends AbstractMojo {
     fmt.setSuppressDeclaration(suppressDeclaration);
     fmt.setTrimText(trimText);
     fmt.setXHTML(xhtml);
+    fmt.setKeepBlankLines(keepBlankLines);
     return fmt;
   }
 

--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -1,0 +1,118 @@
+/*-
+ * #%L
+ * XML Format Maven Plugin
+ * %%
+ * Copyright (C) 2011 - 2021 Acegi Technology Pty Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package au.com.acegi.xmlformat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.StringTokenizer;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dom4j.Node;
+import org.dom4j.io.XMLWriter;
+
+
+/**
+ * Subclass of {@link XMLWriter} that preserves blank lines in outupt (at most one of them, among
+ * two subsequent tags).
+ */
+class BlankLinesWriter extends XMLWriter {
+
+  BlankLinesWriter(final OutputStream out, final XmlOutputFormat fmt)
+      throws UnsupportedEncodingException {
+    super(out, fmt);
+  }
+
+  @Override
+  protected void writeString(final String text) throws IOException {
+    if ((text != null) && (text.length() > 0)) {
+      String input = text;
+      if (isEscapeText()) {
+        input = escapeElementEntities(text);
+      }
+
+      if (getOutputFormat().isTrimText()) {
+        boolean first = true;
+        final StringTokenizer tokenizer = new StringTokenizer(input, " \t\r\f");
+
+        final NewLinesHandler newLinesHandler = new NewLinesHandler();
+        while (tokenizer.hasMoreTokens()) {
+          final String token = tokenizer.nextToken();
+
+          if (newLinesHandler.processToken(token)) {
+            continue;
+          }
+
+          if (first) {
+            first = false;
+            if (lastOutputNodeType == Node.TEXT_NODE) {
+              writer.write(" ");
+            }
+          } else {
+            writer.write(" ");
+          }
+
+          writer.write(token);
+          lastOutputNodeType = Node.TEXT_NODE;
+        }
+        newLinesHandler.finished();
+      } else {
+        lastOutputNodeType = Node.TEXT_NODE;
+        writer.write(input);
+      }
+    }
+  }
+
+  private class NewLinesHandler {
+    private int newLinesCount;
+
+    /**
+     * Processes the token, counting the newlines and producing at most one in output.
+     *
+     * @param token The token to be written
+     * @return True if the token needs to be skipped (it's a newline or a set of newlines)
+     * @throws IOException If an I/O error occurs. 
+     */
+    private boolean processToken(final String token) throws IOException {
+      final int tokenNewLines = StringUtils.countMatches(token, '\n');
+      if (tokenNewLines > 0) {
+        newLinesCount += tokenNewLines;
+        return true;
+      } else if (newLinesCount > 1) {
+        writer.write("\n");
+        newLinesCount = 0;
+      }
+      return false;
+    }
+
+    /**
+     * Marks the end of token streams, allows to emit a last newlines if the last tokens were all
+     * newlines.
+     *
+     * @throws IOException If an I/O error occurs.
+     */
+    private void finished() throws IOException {
+      if (newLinesCount > 1) {
+        writer.write("\n");
+      }
+    }
+  }
+}

--- a/src/main/java/au/com/acegi/xmlformat/FormatUtil.java
+++ b/src/main/java/au/com/acegi/xmlformat/FormatUtil.java
@@ -30,12 +30,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
-import org.dom4j.io.OutputFormat;
 import org.dom4j.io.SAXReader;
 import org.dom4j.io.XMLWriter;
 import org.xml.sax.EntityResolver;
@@ -65,7 +65,7 @@ final class FormatUtil {
    * @throws IOException       if output XML stream could not be written
    */
   static void format(final InputStream in, final OutputStream out,
-                     final OutputFormat fmt) throws DocumentException,
+                     final XmlOutputFormat fmt) throws DocumentException,
                                                     IOException {
     final SAXReader reader = new SAXReader();
     reader.setEntityResolver(new EntityResolver() {
@@ -78,9 +78,20 @@ final class FormatUtil {
     });
     final Document xmlDoc = reader.read(in);
 
-    final XMLWriter xmlWriter = new XMLWriter(out, fmt);
+    final XMLWriter xmlWriter = getXmlWriter(out, fmt);
     xmlWriter.write(xmlDoc);
     xmlWriter.flush();
+  }
+
+  private static XMLWriter getXmlWriter(final OutputStream out, final XmlOutputFormat fmt) 
+          throws UnsupportedEncodingException {
+    final XMLWriter xmlWriter;
+    if (fmt.isKeepBlankLines()) {
+      xmlWriter = new BlankLinesWriter(out, fmt);
+    } else {
+      xmlWriter = new XMLWriter(out, fmt);
+    }
+    return xmlWriter;
   }
 
   /**
@@ -93,7 +104,7 @@ final class FormatUtil {
    * @throws DocumentException if input XML could not be parsed
    * @throws IOException       if output XML stream could not be written
    */
-  static boolean formatInPlace(final File file, final OutputFormat fmt)
+  static boolean formatInPlace(final File file, final XmlOutputFormat fmt)
       throws DocumentException, IOException {
     if (file.length() == 0) {
       return false;
@@ -129,7 +140,7 @@ final class FormatUtil {
    * @throws DocumentException if input XML could not be parsed
    * @throws IOException       if output XML stream could not be written
    */
-  static boolean needsFormatting(final File file, final OutputFormat fmt)
+  static boolean needsFormatting(final File file, final XmlOutputFormat fmt)
       throws DocumentException, IOException {
     if (file.length() == 0) {
       return false;
@@ -147,4 +158,5 @@ final class FormatUtil {
     final long hashTmp = hash(tmpFile);
     return hashFile != hashTmp;
   }
+
 }

--- a/src/main/java/au/com/acegi/xmlformat/XmlCheckPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlCheckPlugin.java
@@ -30,7 +30,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.dom4j.DocumentException;
-import org.dom4j.io.OutputFormat;
 
 /**
  * Finds the XML files in a project and only check them: no files are changed,
@@ -41,7 +40,7 @@ import org.dom4j.io.OutputFormat;
 public final class XmlCheckPlugin extends AbstractXmlPlugin {
 
   @Override
-  protected boolean processFile(final File input, final OutputFormat fmt)
+  protected boolean processFile(final File input, final XmlOutputFormat fmt)
       throws DocumentException, IOException {
     final boolean needsFormatting = needsFormatting(input, fmt);
     final Log log = getLog();

--- a/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.dom4j.DocumentException;
-import org.dom4j.io.OutputFormat;
 
 /**
  * Finds the XML files in a project and automatically reformats them.
@@ -37,7 +36,7 @@ import org.dom4j.io.OutputFormat;
 public final class XmlFormatPlugin extends AbstractXmlPlugin {
 
   @Override
-  protected boolean processFile(final File input, final OutputFormat fmt)
+  protected boolean processFile(final File input, final XmlOutputFormat fmt)
       throws DocumentException, IOException {
     final boolean changed = formatInPlace(input, fmt);
     if (getLog().isDebugEnabled()) {

--- a/src/main/java/au/com/acegi/xmlformat/XmlOutputFormat.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlOutputFormat.java
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * XML Format Maven Plugin
+ * %%
+ * Copyright (C) 2011 - 2021 Acegi Technology Pty Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package au.com.acegi.xmlformat;
+
+import org.dom4j.io.OutputFormat;
+
+/**
+ * Extended DOM4J configuration.
+ *
+ * <ul>
+ *   <li>Defaults to pretty print.
+ *   <li>Adds an option to keep blank lines.
+ * </ul>
+ */
+public class XmlOutputFormat extends OutputFormat {
+
+  private boolean keepBlankLines;
+
+  public XmlOutputFormat() {
+    // same as pretty print
+    setIndentSize(2);
+    setNewlines(true);
+    setTrimText(true);
+    setPadText(true);
+  }
+
+  /**
+   * When set to true, preserves at most one blank line between tags, if it was alredy present in
+   * the input file. Defaults to <code>false</code>.
+   * @return Whether blank lines are preserved, or not.
+   */
+  public boolean isKeepBlankLines() {
+    return keepBlankLines;
+  }
+
+  /**
+   * When set to true, preserves at most one blank line between tags, if it was alredy present in
+   * the input file.
+   *
+   * @param keepBlankLines true to preserve at most one blank line, false to remove all blank lines.
+   */
+  public void setKeepBlankLines(final boolean keepBlankLines) {
+    this.keepBlankLines = keepBlankLines;
+  }
+}

--- a/src/test/resources/test1-out-kbl.xml
+++ b/src/test/resources/test1-out-kbl.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+
+    <name>Coco Puff</name>
+    <total>10</total>
+</root>

--- a/src/test/resources/test2-out-kbl.xml
+++ b/src/test/resources/test2-out-kbl.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+
+    <artifactId>oss-parent</artifactId>
+    <version>9</version>
+  </parent>
+  <groupId>au.com.acegi.xmlformat</groupId>
+
+  <artifactId>xml-format-maven-plugin</artifactId>
+  <version>1.0.0</version>
+
+  <packaging>maven-plugin</packaging>
+
+</project>

--- a/src/test/resources/test4-out-kbl.xml
+++ b/src/test/resources/test4-out-kbl.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+
+		<artifactId>oss-parent</artifactId>
+		<version>9</version>
+	</parent>
+	<groupId>au.com.acegi.xmlformat</groupId>
+
+	<artifactId>xml-format-maven-plugin</artifactId>
+	<version>1.0.0</version>
+
+	<packaging>maven-plugin</packaging>
+
+</project>

--- a/src/test/resources/test5-out-kbl.xml
+++ b/src/test/resources/test5-out-kbl.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<data>
+    <field-a>blah</field-a>
+    <field-b>blah</field-b>
+    <chars><![CDATA[
+            a
+            b
+            c
+            d]]></chars>
+</data>


### PR DESCRIPTION
This PR adds an option to [preserve empty lines](https://github.com/acegi/xml-format-maven-plugin/issues/11).
It follows up, and replaces, https://github.com/acegi/xml-format-maven-plugin/pull/31.

The new option is called "keepBlankLines", mimics the equivalent parameter in the [sortpom plugin](https://github.com/Ekryd/sortpom/wiki/Parameters).

The "new" dependency on commons-lang3 is not actually new, the library was already in the classpath as part of the basic Maven plugin library set of dependencies, but had to be made explicit due to pom content checks.