### PR TITLE
[pom] Add missing relativePath empty tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
     <groupId>au.com.acegi</groupId>
     <artifactId>acegi-standard-project</artifactId>
     <version>0.6.5</version>
+    <relativePath />
   </parent>
   <groupId>au.com.acegi</groupId>
   <artifactId>xml-format-maven-plugin</artifactId>


### PR DESCRIPTION
without this it expects directory above is the parent which is not the case.  This forces to m2 repository.