### PR TITLE
[pom] Add extra enforcer rule in to actually check binary compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,29 @@
         <jdk>[11,)</jdk>
       </activation>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>3.4.1</version>
+              <configuration>
+                <rules combine.children="append">
+                  <enforceBytecodeVersion>
+                    <maxJdkVersion>${maven.enforcer.java}</maxJdkVersion>
+                  </enforceBytecodeVersion>
+                </rules>
+              </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>extra-enforcer-rules</artifactId>
+                  <version>1.7.0</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <groupId>com.github.ekryd.sortpom</groupId>


### PR DESCRIPTION
checks dependencies we provide to ensure valid.  without this we could update dom4j for example to 2.1.4 and it will pass.  with this it will be blocked as such...

```
[ERROR] Rule 0: org.codehaus.mojo.extraenforcer.dependencies.EnforceBytecodeVersion failed with message:
[ERROR] Found Banned Dependency: org.dom4j:dom4j:jar:2.1.4
[ERROR] Use 'mvn dependency:tree' to locate the source of the banned dependencies.
```