### PR TITLE
Fix defect reported on issue #36 by adjusting tokenization process

### DIFF
--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -75,7 +75,7 @@ class BlankLinesWriter extends XMLWriter {
           writer.write(" ");
         }
 
-        writer.write(token);
+        writer.write(token.trim());
         lastOutputNodeType = Node.TEXT_NODE;
       }
       newLinesHandler.finished();

--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -73,11 +73,7 @@ class BlankLinesWriter extends XMLWriter {
           writer.write(" ");
         }
 
-        if (token.equals("\n")) {
-            writer.write(token);
-        } else {
-            writer.write(token.trim());
-        }
+        writer.write(token.trim());
         lastOutputNodeType = Node.TEXT_NODE;
       }
       newLinesHandler.finished();

--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -59,11 +59,9 @@ class BlankLinesWriter extends XMLWriter {
       while (tokenizer.hasMoreTokens()) {
         final String token = tokenizer.nextToken();
 
-        if (newLinesHandler.processToken(token)) {
-          // Only if more tokens exist, continue
-          if (tokenizer.hasMoreTokens()) {
-              continue;
-          }
+        // Only if more tokens exist, continue
+        if (newLinesHandler.processToken(token) && tokenizer.hasMoreTokens()) {
+          continue;
         }
 
         if (first) {
@@ -75,7 +73,11 @@ class BlankLinesWriter extends XMLWriter {
           writer.write(" ");
         }
 
-        writer.write(token.trim());
+        if (token == "\n") {
+            writer.write(token);
+        } else {
+            writer.write(token.trim());
+        }
         lastOutputNodeType = Node.TEXT_NODE;
       }
       newLinesHandler.finished();

--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -60,7 +60,10 @@ class BlankLinesWriter extends XMLWriter {
         final String token = tokenizer.nextToken();
 
         if (newLinesHandler.processToken(token)) {
-          continue;
+          // Only if more tokens exist, continue
+          if (tokenizer.hasMoreTokens()) {
+              continue;
+          }
         }
 
         if (first) {

--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -96,7 +96,8 @@ class BlankLinesWriter extends XMLWriter {
      *         newlines)
      * @throws IOException If an I/O error occurs.
      */
-    private boolean processToken(final String token, final boolean hasMoreTokens) throws IOException {
+    private boolean processToken(final String token, final boolean hasMoreTokens)
+        throws IOException {
       final int tokenNewLines = StringUtils.countMatches(token, '\n');
       if (tokenNewLines > 0) {
         newLinesCount += tokenNewLines;

--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -60,7 +60,7 @@ class BlankLinesWriter extends XMLWriter {
         final String token = tokenizer.nextToken();
 
         // Only if more tokens exist, continue
-        if (newLinesHandler.processToken(token) && tokenizer.hasMoreTokens()) {
+        if (newLinesHandler.processToken(token, tokenizer.hasMoreTokens())) {
           continue;
         }
 
@@ -91,15 +91,16 @@ class BlankLinesWriter extends XMLWriter {
      * output.
      *
      * @param token The token to be written
+     * @param hasMoreTokens Does more tokens exist
      * @return True if the token needs to be skipped (it's a newline or a set of
      *         newlines)
      * @throws IOException If an I/O error occurs.
      */
-    private boolean processToken(final String token) throws IOException {
+    private boolean processToken(final String token, final boolean hasMoreTokens) throws IOException {
       final int tokenNewLines = StringUtils.countMatches(token, '\n');
       if (tokenNewLines > 0) {
         newLinesCount += tokenNewLines;
-        return true;
+        return hasMoreTokens;
       }
       if (newLinesCount > 1) {
         writer.write("\n");

--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -73,7 +73,7 @@ class BlankLinesWriter extends XMLWriter {
           writer.write(" ");
         }
 
-        if (token == "\n") {
+        if (token.equals("\n")) {
             writer.write(token);
         } else {
             writer.write(token.trim());

--- a/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
@@ -149,7 +149,7 @@ public final class FormatUtilTest {
   public void test6() throws DocumentException, IOException {
     final XmlOutputFormat fmt = new XmlOutputFormat();
     fmt.setIndent("    ");
-    fmt.setNewLineAfterDeclaration(false);
+    fmt.setNewLineAfterDeclaration(true);
     fmt.setPadText(false);
     fmt.setTrimText(true);
     fmt.setKeepBlankLines(true);

--- a/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
@@ -145,6 +145,17 @@ public final class FormatUtilTest {
     testInOut(5, fmt);
   }
 
+  @Test
+  public void test6() throws DocumentException, IOException {
+    final XmlOutputFormat fmt = new XmlOutputFormat();
+    fmt.setIndent("    ");
+    fmt.setNewLineAfterDeclaration(false);
+    fmt.setPadText(false);
+    fmt.setTrimText(true);
+    fmt.setKeepBlankLines(true);
+    testInOut(6, fmt);
+  }
+
   @Test(expected = DocumentException.class)
   public void testInvalid() throws DocumentException, IOException {
     try (InputStream in = getResource("/invalid.xml")) {

--- a/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.dom4j.DocumentException;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -133,22 +132,27 @@ public final class FormatUtilTest {
    * New lines between the XML declaration and the root elements are ignored at the parse level it
    * seems, they don't reach the XMLWriter. Not ideal, but believe we can leave with this exception
    */
-  @Ignore
   @Test
   public void test5KeepBlankLines() throws DocumentException, IOException {
     final XmlOutputFormat fmt = new XmlOutputFormat();
     fmt.setIndent("    ");
-    fmt.setNewLineAfterDeclaration(false);
+    // Set to true to keep the new line given keep blank lines will not
+    fmt.setNewLineAfterDeclaration(true);
     fmt.setPadText(false);
     fmt.setTrimText(true);
     fmt.setKeepBlankLines(true);
     testInOut(5, fmt);
   }
 
+  /**
+   * New lines between the XML declaration and the root elements are ignored at the parse level it
+   * seems, they don't reach the XMLWriter. Not ideal, but believe we can leave with this exception
+   */
   @Test
   public void test6() throws DocumentException, IOException {
     final XmlOutputFormat fmt = new XmlOutputFormat();
     fmt.setIndent("    ");
+    // Set to true to keep the new line given keep blank lines will not
     fmt.setNewLineAfterDeclaration(true);
     fmt.setPadText(false);
     fmt.setTrimText(true);

--- a/src/test/resources/test6-in.xml
+++ b/src/test/resources/test6-in.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <test>${project.build.directory}/reports/json/
+    </test>
+</project>

--- a/src/test/resources/test6-in.xml
+++ b/src/test/resources/test6-in.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <test>${project.build.directory}/reports/json/
     </test>

--- a/src/test/resources/test6-out-kbl.xml
+++ b/src/test/resources/test6-out-kbl.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <test>${project.build.directory}/reports/json/</test>
+</project>

--- a/src/test/resources/test6-out.xml
+++ b/src/test/resources/test6-out.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <test>${project.build.directory}/reports/json/</test>
+</project>


### PR DESCRIPTION
Fixes #36 

When tokenization is done for keep blank lines, it fails to understand that line may be text plus new line.  This happens because '\n' is ignored on delimitation and line can have that as trailing value.  This results in the process stripping out valid data.  To fix this, send the hasMoreTokens boolean to the new lines handler.  After existing processing, instead of passing 'true' back, pass the hasMoreTokens back.  This will now allow it to print the value instead of stripping it.  However, trim the data as we need the trailing \n (or potentially others) removed.  The finalization on new lines handler will add the expected 1 new line.

While doing this, the one test ignore had same consideration as used for the base test for this issue.  As such, fix that test and enable it along with another comment related to it.