### PR TITLE
Java 8 / Maven 3.6.3 / Correct Maven scopes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,6 +73,32 @@ jobs:
       - name: Test with Maven
         run: ./mvnw -B -V test
 
+  compatibility-checks-java8-maven400:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        java: [8]
+
+    name: Java ${{ matrix.java }} Compatibility with Maven 4.0.0-beta-4
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: ${{ matrix.java }}
+          cache: maven
+
+      - name: Load Maven 4.0.0-beta-4
+        run: mvn -B -V org.apache.maven.plugins::maven-wrapper-plugin:3.3.2:wrapper -Dmaven=4.0.0-beta-4 --no-transfer-progress
+
+      - name: Test with Maven
+        run: ./mvnw -B -V test
+
   deploy:
     name: Deploy to OSSRH
     needs: [build, compatibility-checks]

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,12 +73,12 @@ jobs:
       - name: Test with Maven
         run: ./mvnw -B -V test
 
-  compatibility-checks-java8-maven400:
+  compatibility-checks-java17-maven400:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        java: [8]
+        java: [17]
 
     name: Java ${{ matrix.java }} Compatibility with Maven 4.0.0-beta-4
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [8, 11, 17, 21, 22-ea]
+        java: [8, 11, 17, 21, 22, 23-ea, 24-ea]
 
     name: Java ${{ matrix.java }} Compatibility
 
@@ -47,14 +47,14 @@ jobs:
       - name: Test with Maven
         run: ./mvnw -B -V test
 
-  compatibility-checks-java7-maven354:
+  compatibility-checks-java8-maven363:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        java: [7]
+        java: [8]
 
-    name: Java ${{ matrix.java }} Compatibility with Maven 3.5.4
+    name: Java ${{ matrix.java }} Compatibility with Maven 3.6.3
 
     steps:
       - name: Check out Git repository
@@ -67,8 +67,8 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
 
-      - name: Load Maven 3.5.4
-        run: mvn -B -V io.takari:maven:0.5.0:wrapper -Dmaven=3.5.4 --no-transfer-progress
+      - name: Load Maven 3.6.3
+        run: mvn -B -V org.apache.maven.plugins::maven-wrapper-plugin:3.3.2:wrapper -Dmaven=3.6.3 --no-transfer-progress
 
       - name: Test with Maven
         run: ./mvnw -B -V test
@@ -87,14 +87,14 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 17
+        java-version: 21
         cache: maven
 
     - name: Set up Java and Maven
       uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 17
+        java-version: 21
         cache: maven
         server-id: ossrh
         server-username: MAVEN_USERNAME

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ release.properties
 .checkstyle
 .factorypath
 .fbExcludeFilterFile
+.pmd
+.pmdruleset.xml

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+      <groupId>fr.jcgay.maven</groupId>
+      <artifactId>maven-profiler</artifactId>
+      <version>3.2</version>
+    </extension>
+</extensions>

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -21,77 +21,72 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ThreadLocalRandom;
 
-public final class MavenWrapperDownloader
-{
-    private static final String WRAPPER_VERSION = "3.2.0";
+public final class MavenWrapperDownloader {
+    private static final String WRAPPER_VERSION = "3.3.2";
 
-    private static final boolean VERBOSE = Boolean.parseBoolean( System.getenv( "MVNW_VERBOSE" ) );
+    private static final boolean VERBOSE = Boolean.parseBoolean(System.getenv("MVNW_VERBOSE"));
 
-    public static void main( String[] args )
-    {
-        log( "Apache Maven Wrapper Downloader " + WRAPPER_VERSION );
+    public static void main(String[] args) {
+        log("Apache Maven Wrapper Downloader " + WRAPPER_VERSION);
 
-        if ( args.length != 2 )
-        {
-            System.err.println( " - ERROR wrapperUrl or wrapperJarPath parameter missing" );
-            System.exit( 1 );
+        if (args.length != 2) {
+            System.err.println(" - ERROR wrapperUrl or wrapperJarPath parameter missing");
+            System.exit(1);
         }
 
-        try
-        {
-            log( " - Downloader started" );
-            final URL wrapperUrl = new URL( args[0] );
-            final String jarPath = args[1].replace( "..", "" ); // Sanitize path
-            final Path wrapperJarPath = Paths.get( jarPath ).toAbsolutePath().normalize();
-            downloadFileFromURL( wrapperUrl, wrapperJarPath );
-            log( "Done" );
-        }
-        catch ( IOException e )
-        {
-            System.err.println( "- Error downloading: " + e.getMessage() );
-            if ( VERBOSE )
-            {
+        try {
+            log(" - Downloader started");
+            final URL wrapperUrl = URI.create(args[0]).toURL();
+            final String jarPath = args[1].replace("..", ""); // Sanitize path
+            final Path wrapperJarPath = Paths.get(jarPath).toAbsolutePath().normalize();
+            downloadFileFromURL(wrapperUrl, wrapperJarPath);
+            log("Done");
+        } catch (IOException e) {
+            System.err.println("- Error downloading: " + e.getMessage());
+            if (VERBOSE) {
                 e.printStackTrace();
             }
-            System.exit( 1 );
+            System.exit(1);
         }
     }
 
-    private static void downloadFileFromURL( URL wrapperUrl, Path wrapperJarPath )
-        throws IOException
-    {
-        log( " - Downloading to: " + wrapperJarPath );
-        if ( System.getenv( "MVNW_USERNAME" ) != null && System.getenv( "MVNW_PASSWORD" ) != null )
-        {
-            final String username = System.getenv( "MVNW_USERNAME" );
-            final char[] password = System.getenv( "MVNW_PASSWORD" ).toCharArray();
-            Authenticator.setDefault( new Authenticator()
-            {
+    private static void downloadFileFromURL(URL wrapperUrl, Path wrapperJarPath)
+            throws IOException {
+        log(" - Downloading to: " + wrapperJarPath);
+        if (System.getenv("MVNW_USERNAME") != null && System.getenv("MVNW_PASSWORD") != null) {
+            final String username = System.getenv("MVNW_USERNAME");
+            final char[] password = System.getenv("MVNW_PASSWORD").toCharArray();
+            Authenticator.setDefault(new Authenticator() {
                 @Override
-                protected PasswordAuthentication getPasswordAuthentication()
-                {
-                    return new PasswordAuthentication( username, password );
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username, password);
                 }
-            } );
+            });
         }
-        try ( InputStream inStream = wrapperUrl.openStream() )
-        {
-            Files.copy( inStream, wrapperJarPath, StandardCopyOption.REPLACE_EXISTING );
+        Path temp = wrapperJarPath
+                .getParent()
+                .resolve(wrapperJarPath.getFileName() + "."
+                        + Long.toUnsignedString(ThreadLocalRandom.current().nextLong()) + ".tmp");
+        try (InputStream inStream = wrapperUrl.openStream()) {
+            Files.copy(inStream, temp, StandardCopyOption.REPLACE_EXISTING);
+            Files.move(temp, wrapperJarPath, StandardCopyOption.REPLACE_EXISTING);
+        } finally {
+            Files.deleteIfExists(temp);
         }
-        log( " - Downloader complete" );
+        log(" - Downloader complete");
     }
 
-    private static void log( String msg )
-    {
-        if ( VERBOSE )
-        {
-            System.out.println( msg );
+    private static void log(String msg) {
+        if (VERBOSE) {
+            System.out.println(msg);
         }
     }
 

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+wrapperVersion=3.3.2
+distributionType=source
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.2.0
+# Apache Maven Wrapper startup batch script, version 3.3.2
 #
 # Required ENV vars:
 # ------------------
@@ -33,75 +33,84 @@
 #   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
 # ----------------------------------------------------------------------------
 
-if [ -z "$MAVEN_SKIP_RC" ] ; then
+if [ -z "$MAVEN_SKIP_RC" ]; then
 
-  if [ -f /usr/local/etc/mavenrc ] ; then
+  if [ -f /usr/local/etc/mavenrc ]; then
     . /usr/local/etc/mavenrc
   fi
 
-  if [ -f /etc/mavenrc ] ; then
+  if [ -f /etc/mavenrc ]; then
     . /etc/mavenrc
   fi
 
-  if [ -f "$HOME/.mavenrc" ] ; then
+  if [ -f "$HOME/.mavenrc" ]; then
     . "$HOME/.mavenrc"
   fi
 
 fi
 
 # OS specific support.  $var _must_ be set to either true or false.
-cygwin=false;
-darwin=false;
+cygwin=false
+darwin=false
 mingw=false
 case "$(uname)" in
-  CYGWIN*) cygwin=true ;;
-  MINGW*) mingw=true;;
-  Darwin*) darwin=true
-    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
-    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
-    if [ -z "$JAVA_HOME" ]; then
-      if [ -x "/usr/libexec/java_home" ]; then
-        JAVA_HOME="$(/usr/libexec/java_home)"; export JAVA_HOME
-      else
-        JAVA_HOME="/Library/Java/Home"; export JAVA_HOME
-      fi
+CYGWIN*) cygwin=true ;;
+MINGW*) mingw=true ;;
+Darwin*)
+  darwin=true
+  # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+  # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+  if [ -z "$JAVA_HOME" ]; then
+    if [ -x "/usr/libexec/java_home" ]; then
+      JAVA_HOME="$(/usr/libexec/java_home)"
+      export JAVA_HOME
+    else
+      JAVA_HOME="/Library/Java/Home"
+      export JAVA_HOME
     fi
-    ;;
+  fi
+  ;;
 esac
 
-if [ -z "$JAVA_HOME" ] ; then
-  if [ -r /etc/gentoo-release ] ; then
+if [ -z "$JAVA_HOME" ]; then
+  if [ -r /etc/gentoo-release ]; then
     JAVA_HOME=$(java-config --jre-home)
   fi
 fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
-if $cygwin ; then
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
-  [ -n "$CLASSPATH" ] &&
-    CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] \
+    && JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] \
+    && CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
 fi
 
 # For Mingw, ensure paths are in UNIX format before anything is touched
-if $mingw ; then
-  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] &&
-    JAVA_HOME="$(cd "$JAVA_HOME" || (echo "cannot cd into $JAVA_HOME."; exit 1); pwd)"
+if $mingw; then
+  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] \
+    && JAVA_HOME="$(
+      cd "$JAVA_HOME" || (
+        echo "cannot cd into $JAVA_HOME." >&2
+        exit 1
+      )
+      pwd
+    )"
 fi
 
 if [ -z "$JAVA_HOME" ]; then
   javaExecutable="$(which javac)"
-  if [ -n "$javaExecutable" ] && ! [ "$(expr "\"$javaExecutable\"" : '\([^ ]*\)')" = "no" ]; then
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "$javaExecutable" : '\([^ ]*\)')" = "no" ]; then
     # readlink(1) is not available as standard on Solaris 10.
     readLink=$(which readlink)
     if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
-      if $darwin ; then
-        javaHome="$(dirname "\"$javaExecutable\"")"
-        javaExecutable="$(cd "\"$javaHome\"" && pwd -P)/javac"
+      if $darwin; then
+        javaHome="$(dirname "$javaExecutable")"
+        javaExecutable="$(cd "$javaHome" && pwd -P)/javac"
       else
-        javaExecutable="$(readlink -f "\"$javaExecutable\"")"
+        javaExecutable="$(readlink -f "$javaExecutable")"
       fi
-      javaHome="$(dirname "\"$javaExecutable\"")"
+      javaHome="$(dirname "$javaExecutable")"
       javaHome=$(expr "$javaHome" : '\(.*\)/bin')
       JAVA_HOME="$javaHome"
       export JAVA_HOME
@@ -109,52 +118,60 @@ if [ -z "$JAVA_HOME" ]; then
   fi
 fi
 
-if [ -z "$JAVACMD" ] ; then
-  if [ -n "$JAVA_HOME"  ] ; then
-    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+if [ -z "$JAVACMD" ]; then
+  if [ -n "$JAVA_HOME" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
       # IBM's JDK on AIX uses strange locations for the executables
       JAVACMD="$JAVA_HOME/jre/sh/java"
     else
       JAVACMD="$JAVA_HOME/bin/java"
     fi
   else
-    JAVACMD="$(\unset -f command 2>/dev/null; \command -v java)"
+    JAVACMD="$(
+      \unset -f command 2>/dev/null
+      \command -v java
+    )"
   fi
 fi
 
-if [ ! -x "$JAVACMD" ] ; then
+if [ ! -x "$JAVACMD" ]; then
   echo "Error: JAVA_HOME is not defined correctly." >&2
   echo "  We cannot execute $JAVACMD" >&2
   exit 1
 fi
 
-if [ -z "$JAVA_HOME" ] ; then
-  echo "Warning: JAVA_HOME environment variable is not set."
+if [ -z "$JAVA_HOME" ]; then
+  echo "Warning: JAVA_HOME environment variable is not set." >&2
 fi
 
 # traverses directory structure from process work directory to filesystem root
 # first directory with .mvn subdirectory is considered project base directory
 find_maven_basedir() {
-  if [ -z "$1" ]
-  then
-    echo "Path not specified to find_maven_basedir"
+  if [ -z "$1" ]; then
+    echo "Path not specified to find_maven_basedir" >&2
     return 1
   fi
 
   basedir="$1"
   wdir="$1"
-  while [ "$wdir" != '/' ] ; do
-    if [ -d "$wdir"/.mvn ] ; then
+  while [ "$wdir" != '/' ]; do
+    if [ -d "$wdir"/.mvn ]; then
       basedir=$wdir
       break
     fi
     # workaround for JBEAP-8937 (on Solaris 10/Sparc)
     if [ -d "${wdir}" ]; then
-      wdir=$(cd "$wdir/.." || exit 1; pwd)
+      wdir=$(
+        cd "$wdir/.." || exit 1
+        pwd
+      )
     fi
     # end of workaround
   done
-  printf '%s' "$(cd "$basedir" || exit 1; pwd)"
+  printf '%s' "$(
+    cd "$basedir" || exit 1
+    pwd
+  )"
 }
 
 # concatenates all lines of a file
@@ -165,7 +182,7 @@ concat_lines() {
     # enabled. Otherwise, we may read lines that are delimited with
     # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
     # splitting rules.
-    tr -s '\r\n' ' ' < "$1"
+    tr -s '\r\n' ' ' <"$1"
   fi
 }
 
@@ -177,10 +194,11 @@ log() {
 
 BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
 if [ -z "$BASE_DIR" ]; then
-  exit 1;
+  exit 1
 fi
 
-MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}; export MAVEN_PROJECTBASEDIR
+MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
+export MAVEN_PROJECTBASEDIR
 log "$MAVEN_PROJECTBASEDIR"
 
 ##########################################################################################
@@ -189,63 +207,66 @@ log "$MAVEN_PROJECTBASEDIR"
 ##########################################################################################
 wrapperJarPath="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
 if [ -r "$wrapperJarPath" ]; then
-    log "Found $wrapperJarPath"
+  log "Found $wrapperJarPath"
 else
-    log "Couldn't find $wrapperJarPath, downloading it ..."
+  log "Couldn't find $wrapperJarPath, downloading it ..."
 
-    if [ -n "$MVNW_REPOURL" ]; then
-      wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+  if [ -n "$MVNW_REPOURL" ]; then
+    wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar"
+  else
+    wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar"
+  fi
+  while IFS="=" read -r key value; do
+    # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
+    safeValue=$(echo "$value" | tr -d '\r')
+    case "$key" in wrapperUrl)
+      wrapperUrl="$safeValue"
+      break
+      ;;
+    esac
+  done <"$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+  log "Downloading from: $wrapperUrl"
+
+  if $cygwin; then
+    wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+  fi
+
+  if command -v wget >/dev/null; then
+    log "Found wget ... using wget"
+    [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
+    if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+      wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
     else
-      wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+      wget $QUIET --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
     fi
-    while IFS="=" read -r key value; do
-      # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
-      safeValue=$(echo "$value" | tr -d '\r')
-      case "$key" in (wrapperUrl) wrapperUrl="$safeValue"; break ;;
-      esac
-    done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
-    log "Downloading from: $wrapperUrl"
-
+  elif command -v curl >/dev/null; then
+    log "Found curl ... using curl"
+    [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
+    if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+      curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+    else
+      curl $QUIET --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+    fi
+  else
+    log "Falling back to using Java to download"
+    javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
+    javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
+    # For Cygwin, switch paths to Windows format before running javac
     if $cygwin; then
-      wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+      javaSource=$(cygpath --path --windows "$javaSource")
+      javaClass=$(cygpath --path --windows "$javaClass")
     fi
-
-    if command -v wget > /dev/null; then
-        log "Found wget ... using wget"
-        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
-        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
-        else
-            wget $QUIET --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
-        fi
-    elif command -v curl > /dev/null; then
-        log "Found curl ... using curl"
-        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
-        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
-        else
-            curl $QUIET --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
-        fi
-    else
-        log "Falling back to using Java to download"
-        javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
-        javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
-        # For Cygwin, switch paths to Windows format before running javac
-        if $cygwin; then
-          javaSource=$(cygpath --path --windows "$javaSource")
-          javaClass=$(cygpath --path --windows "$javaClass")
-        fi
-        if [ -e "$javaSource" ]; then
-            if [ ! -e "$javaClass" ]; then
-                log " - Compiling MavenWrapperDownloader.java ..."
-                ("$JAVA_HOME/bin/javac" "$javaSource")
-            fi
-            if [ -e "$javaClass" ]; then
-                log " - Running MavenWrapperDownloader.java ..."
-                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
-            fi
-        fi
+    if [ -e "$javaSource" ]; then
+      if [ ! -e "$javaClass" ]; then
+        log " - Compiling MavenWrapperDownloader.java ..."
+        ("$JAVA_HOME/bin/javac" "$javaSource")
+      fi
+      if [ -e "$javaClass" ]; then
+        log " - Running MavenWrapperDownloader.java ..."
+        ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
+      fi
     fi
+  fi
 fi
 ##########################################################################################
 # End of extension
@@ -254,22 +275,25 @@ fi
 # If specified, validate the SHA-256 sum of the Maven wrapper jar file
 wrapperSha256Sum=""
 while IFS="=" read -r key value; do
-  case "$key" in (wrapperSha256Sum) wrapperSha256Sum=$value; break ;;
+  case "$key" in wrapperSha256Sum)
+    wrapperSha256Sum=$value
+    break
+    ;;
   esac
-done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+done <"$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
 if [ -n "$wrapperSha256Sum" ]; then
   wrapperSha256Result=false
-  if command -v sha256sum > /dev/null; then
-    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c > /dev/null 2>&1; then
+  if command -v sha256sum >/dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c >/dev/null 2>&1; then
       wrapperSha256Result=true
     fi
-  elif command -v shasum > /dev/null; then
-    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c > /dev/null 2>&1; then
+  elif command -v shasum >/dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c >/dev/null 2>&1; then
       wrapperSha256Result=true
     fi
   else
-    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available."
-    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties."
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   fi
   if [ $wrapperSha256Result = false ]; then
@@ -284,12 +308,12 @@ MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
-  [ -n "$CLASSPATH" ] &&
-    CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
-  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
-    MAVEN_PROJECTBASEDIR=$(cygpath --path --windows "$MAVEN_PROJECTBASEDIR")
+  [ -n "$JAVA_HOME" ] \
+    && JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] \
+    && CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
+  [ -n "$MAVEN_PROJECTBASEDIR" ] \
+    && MAVEN_PROJECTBASEDIR=$(cygpath --path --windows "$MAVEN_PROJECTBASEDIR")
 fi
 
 # Provide a "standardized" way to retrieve the CLI args that will

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -18,7 +18,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Apache Maven Wrapper startup batch script, version 3.2.0
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
 @REM
 @REM Required ENV vars:
 @REM JAVA_HOME - location of a JDK home dir
@@ -59,22 +59,22 @@ set ERROR_CODE=0
 @REM ==== START VALIDATION ====
 if not "%JAVA_HOME%" == "" goto OkJHome
 
-echo.
+echo. >&2
 echo Error: JAVA_HOME not found in your environment. >&2
 echo Please set the JAVA_HOME variable in your environment to match the >&2
 echo location of your Java installation. >&2
-echo.
+echo. >&2
 goto error
 
 :OkJHome
 if exist "%JAVA_HOME%\bin\java.exe" goto init
 
-echo.
+echo. >&2
 echo Error: JAVA_HOME is set to an invalid directory. >&2
 echo JAVA_HOME = "%JAVA_HOME%" >&2
 echo Please set the JAVA_HOME variable in your environment to match the >&2
 echo location of your Java installation. >&2
-echo.
+echo. >&2
 goto error
 
 @REM ==== END VALIDATION ====
@@ -119,7 +119,7 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set WRAPPER_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+set WRAPPER_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar"
 
 FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET WRAPPER_URL=%%B
@@ -133,7 +133,7 @@ if exist %WRAPPER_JAR% (
     )
 ) else (
     if not "%MVNW_REPOURL%" == "" (
-        SET WRAPPER_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+        SET WRAPPER_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar"
     )
     if "%MVNW_VERBOSE%" == "true" (
         echo Couldn't find %WRAPPER_JAR%, downloading it ...
@@ -160,11 +160,12 @@ FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapp
 )
 IF NOT %WRAPPER_SHA_256_SUM%=="" (
     powershell -Command "&{"^
+       "Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash;"^
        "$hash = (Get-FileHash \"%WRAPPER_JAR%\" -Algorithm SHA256).Hash.ToLower();"^
        "If('%WRAPPER_SHA_256_SUM%' -ne $hash){"^
-       "  Write-Output 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
-       "  Write-Output 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
-       "  Write-Output 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
+       "  Write-Error 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
+       "  Write-Error 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
+       "  Write-Error 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
        "  exit 1;"^
        "}"^
        "}"

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <groupId>au.com.acegi</groupId>
     <artifactId>acegi-standard-project</artifactId>
     <version>0.6.5</version>
-    <relativePath/>
+    <relativePath />
   </parent>
   <groupId>au.com.acegi</groupId>
   <artifactId>xml-format-maven-plugin</artifactId>
-  <version>3.2.3-SNAPSHOT</version>
+  <version>3.3.0</version>
   <packaging>maven-plugin</packaging>
   <name>XML Format Maven Plugin</name>
   <description>Automatically formats XML files in a project.</description>
@@ -132,7 +132,7 @@
     <connection>scm:git:git@github.com:${github.org}/${github.repo}.git</connection>
     <developerConnection>scm:git:git@github.com:${github.org}/${github.repo}.git</developerConnection>
     <url>git@github.com:${github.org}/${github.repo}.git</url>
-    <tag>HEAD</tag>
+    <tag>xml-format-maven-plugin-3.3.0</tag>
   </scm>
   <issueManagement>
     <system>GitHub Issues</system>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>2.0.3</version>
+      <version>2.1.4</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,20 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.12</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- ignore transitive dependency of maven to ensure provided scope -->
+            <ignore>org.apache.maven:maven-artifact</ignore>
+            <!-- ignore transitive dependency of maven to ensure provided scope -->
+            <ignore>org.apache.maven:maven-core</ignore>
+            <!-- ignore alignment with plexus-xml as required to ensure plexus-utils uses maven 3 -->
+            <ignore>org.codehaus.plexus:plexus-xml</ignore>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <inceptionYear>2011</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,12 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.5.1</version>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.17.0</version>
@@ -74,6 +70,11 @@
       <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <version>2.1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
+      <version>3.13.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.9.0</version>
+      <version>3.10.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -105,7 +105,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.9.0</version>
+        <version>3.10.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.target>8</maven.compiler.target>
     <maven.enforcer.java>8</maven.enforcer.java>
     <mockito.version>4.11.0</mockito.version>
-    <pmd.version>7.5.0</pmd.version>
+    <pmd.version>6.55.0</pmd.version>
     <spotbugs.skip>true</spotbugs.skip>
     <xml-format.skip>true</xml-format.skip>
   </properties>
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.25.0</version>
+        <version>3.21.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>au.com.acegi</groupId>
     <artifactId>acegi-standard-project</artifactId>
     <version>0.7.0</version>
-    <relativePath />
+    <relativePath/>
   </parent>
   <groupId>au.com.acegi</groupId>
   <artifactId>xml-format-maven-plugin</artifactId>
@@ -27,6 +27,11 @@
     <xml-format.skip>true</xml-format.skip>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
@@ -72,11 +77,6 @@
       <version>2.1.4</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>
@@ -104,6 +104,20 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- ignore transitive dependency of maven to ensure provided scope -->
+            <ignore>org.apache.maven:maven-artifact</ignore>
+            <!-- ignore transitive dependency of maven to ensure provided scope -->
+            <ignore>org.apache.maven:maven-core</ignore>
+            <!-- ignore alignment with plexus-xml as required to ensure plexus-utils uses maven 3 -->
+            <ignore>org.codehaus.plexus:plexus-xml</ignore>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -140,20 +154,6 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.12</version>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <ignoredUnusedDeclaredDependencies>
-            <!-- ignore transitive dependency of maven to ensure provided scope -->
-            <ignore>org.apache.maven:maven-artifact</ignore>
-            <!-- ignore transitive dependency of maven to ensure provided scope -->
-            <ignore>org.apache.maven:maven-core</ignore>
-            <!-- ignore alignment with plexus-xml as required to ensure plexus-utils uses maven 3 -->
-            <ignore>org.codehaus.plexus:plexus-xml</ignore>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <inceptionYear>2011</inceptionYear>
@@ -178,8 +178,8 @@
         <jdk>[11,)</jdk>
       </activation>
       <properties>
-          <maven.compiler.release>8</maven.compiler.release>
-          <mockito.version>5.13.0</mockito.version>
+        <maven.compiler.release>8</maven.compiler.release>
+        <mockito.version>5.13.0</mockito.version>
       </properties>
       <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <maven.compiler.target>8</maven.compiler.target>
     <maven.enforcer.java>8</maven.enforcer.java>
     <mockito.version>4.11.0</mockito.version>
+    <pmd.version>7.5.0</pmd.version>
     <spotbugs.skip>true</spotbugs.skip>
     <xml-format.skip>true</xml-format.skip>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,10 @@
       <version>3.6.4</version>
       <scope>provided</scope>
     </dependency>
-    <!-- 3.3.1 is the last version supporting Java 7 -->
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.3.1</version>
+      <version>3.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,8 @@
     <plugins>
       <!-- Maven 4 seems to want maven wrapper defined for some reason. -->
       <plugin>
-        <groupId>org.apache.maven.wrapper</groupId>
-        <artifactId>maven-wrapper</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-wrapper-plugin</artifactId>
         <version>3.3.2</version>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- Mockito 3.0.0 and above requires Java 8 (XML formatter targets Java 7) -->
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
     <github.repo>xml-format-maven-plugin</github.repo>
     <license.excludes>**/test*.xml,**/invalid.xml</license.excludes>
     <license.licenseName>apache_v2</license.licenseName>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.enforcer.java>1.7</maven.enforcer.java>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.enforcer.java>1.8</maven.enforcer.java>
     <spotbugs.skip>true</spotbugs.skip>
     <xml-format.skip>true</xml-format.skip>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <maven.enforcer.java>8</maven.enforcer.java>
+    <mockito.version>4.11.0</mockito.version>
     <spotbugs.skip>true</spotbugs.skip>
     <xml-format.skip>true</xml-format.skip>
   </properties>
@@ -81,7 +82,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.11.0</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -162,6 +163,7 @@
       </activation>
       <properties>
           <maven.compiler.release>8</maven.compiler.release>
+          <mockito.version>5.13.0</mockito.version>
       </properties>
       <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
     <github.repo>xml-format-maven-plugin</github.repo>
     <license.excludes>**/test*.xml,**/invalid.xml</license.excludes>
     <license.licenseName>apache_v2</license.licenseName>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.enforcer.java>1.8</maven.enforcer.java>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.enforcer.java>8</maven.enforcer.java>
     <spotbugs.skip>true</spotbugs.skip>
     <xml-format.skip>true</xml-format.skip>
   </properties>
@@ -160,6 +160,9 @@
       <activation>
         <jdk>[11,)</jdk>
       </activation>
+      <properties>
+          <maven.compiler.release>8</maven.compiler.release>
+      </properties>
       <build>
         <pluginManagement>
           <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
   </dependencies>
   <build>
     <plugins>
+      <!-- Maven 4 seems to want maven wrapper defined for some reason. -->
+      <plugin>
+        <groupId>org.apache.maven.wrapper</groupId>
+        <artifactId>maven-wrapper</artifactId>
+        <version>3.3.2</version>
+      </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
                 <rules combine.children="append">
                   <enforceBytecodeVersion>
                     <maxJdkVersion>${maven.enforcer.java}</maxJdkVersion>
+                    <ignoredScopes>test</ignoredScopes>
                   </enforceBytecodeVersion>
                 </rules>
               </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>au.com.acegi</groupId>
   <artifactId>xml-format-maven-plugin</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>XML Format Maven Plugin</name>
   <description>Automatically formats XML files in a project.</description>
@@ -132,7 +132,7 @@
     <connection>scm:git:git@github.com:${github.org}/${github.repo}.git</connection>
     <developerConnection>scm:git:git@github.com:${github.org}/${github.repo}.git</developerConnection>
     <url>git@github.com:${github.org}/${github.repo}.git</url>
-    <tag>xml-format-maven-plugin-3.3.0</tag>
+    <tag>HEAD</tag>
   </scm>
   <issueManagement>
     <system>GitHub Issues</system>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
       <plugin>
         <groupId>org.basepom.maven</groupId>
         <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <version>2.0.1</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,9 @@
   <packaging>maven-plugin</packaging>
   <name>XML Format Maven Plugin</name>
   <description>Automatically formats XML files in a project.</description>
+  <prerequisites>
+    <maven>3.6.3</maven>
+  </prerequisites>
   <properties>
     <github.org>acegi</github.org>
     <github.repo>xml-format-maven-plugin</github.repo>
@@ -21,6 +24,7 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <maven.enforcer.java>8</maven.enforcer.java>
+    <maven.enforcer.mvn>3.6.3</maven.enforcer.mvn>
     <mockito.version>4.11.0</mockito.version>
     <pmd.version>6.55.0</pmd.version>
     <spotbugs.skip>true</spotbugs.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -29,22 +29,33 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <!-- Commons Lang restricted to 3.8.1 to support Java 7 -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
+      <version>3.12.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.9.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.9.2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.8.8</version>
+      <version>3.9.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.6.4</version>
+      <version>3.9.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -81,47 +92,44 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.3.1</version>
       </plugin>
-      <!-- 3.8.1 required to support Java 7 -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.9.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>3.21.2</version>
       </plugin>
-      <!-- 3.2.0 required to support Java 7 -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.1</version>
       </plugin>
       <plugin>
         <groupId>org.basepom.maven</groupId>
         <artifactId>duplicate-finder-maven-plugin</artifactId>
       </plugin>
-      <!-- 2.0.1 required to support Java 7 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.0.1</version>
+        <version>2.2.0</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>2.16.2</version>
       </plugin>
-      <!-- 0.8.10 required to support Java 7 -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.10</version>
+        <version>0.8.11</version>
       </plugin>
     </plugins>
   </build>
@@ -184,6 +192,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.3.0</version>
           </plugin>
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
@@ -192,17 +201,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>additional-plugins-on-java-21-and-above</id>
-      <activation>
-        <jdk>[21,)</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <maven.enforcer.java>8</maven.enforcer.java>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.4.1</version>
           </plugin>
           <plugin>
             <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,19 +37,19 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>3.9.2</version>
+      <version>3.9.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.9.2</version>
+      <version>3.9.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.9.2</version>
+      <version>3.9.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/AbstractXmlPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
+++ b/src/main/java/au/com/acegi/xmlformat/BlankLinesWriter.java
@@ -83,7 +83,7 @@ class BlankLinesWriter extends XMLWriter {
     }
   }
 
-  private class NewLinesHandler {
+  private final class NewLinesHandler {
     private int newLinesCount;
 
     /**

--- a/src/main/java/au/com/acegi/xmlformat/FormatUtil.java
+++ b/src/main/java/au/com/acegi/xmlformat/FormatUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/IOUtil.java
+++ b/src/main/java/au/com/acegi/xmlformat/IOUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/LineEnding.java
+++ b/src/main/java/au/com/acegi/xmlformat/LineEnding.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/XmlCheckPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlCheckPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlFormatPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/XmlOutputFormat.java
+++ b/src/main/java/au/com/acegi/xmlformat/XmlOutputFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/au/com/acegi/xmlformat/package-info.java
+++ b/src/main/java/au/com/acegi/xmlformat/package-info.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -24,6 +24,7 @@
     <pluginExecution>
       <pluginExecutionFilter>
         <goals>
+          <goal>xml-check</goal>
           <goal>xml-format</goal>
         </goals>
       </pluginExecutionFilter>

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  XML Format Maven Plugin
+  %%
+  Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <lifecycleMappingMetadata>
   <pluginExecutions>
     <pluginExecution>

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>xml-format</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore/>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -3,7 +3,7 @@
   #%L
   XML Format Maven Plugin
   %%
-  Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+  Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/FormatUtilTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/IOTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/IOTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/TestUtil.java
+++ b/src/test/java/au/com/acegi/xmlformat/TestUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/XmlCheckPluginTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/XmlCheckPluginTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/XmlFormatPluginTest.java
+++ b/src/test/java/au/com/acegi/xmlformat/XmlFormatPluginTest.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/au/com/acegi/xmlformat/package-info.java
+++ b/src/test/java/au/com/acegi/xmlformat/package-info.java
@@ -2,7 +2,7 @@
  * #%L
  * XML Format Maven Plugin
  * %%
- * Copyright (C) 2011 - 2023 Acegi Technology Pty Limited
+ * Copyright (C) 2011 - 2024 Acegi Technology Pty Limited
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Been away for a while, brought this up to date with current standards.  I ended up addressing #45 on my fork and let it bring all up to date.

added m2e hint as well (maven 2 eclipse) to just ignore so it doesn't get warnings within eclipse.

This looks like a lot but really isn't. Since I used Renovate, it brought in each PR separately and I merged onto my fork then sent here.  This could be squashed if needed for clarity.

This moves to java 8 now.  Maven itself has flagged all but 3.6.3 as deprecated and moved all core plugins already.  Thus the lowest maven to use now is 3.6.3 or better.  The code is otherwise now compatible with maven 4 as well.